### PR TITLE
make html output content copy-pastable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,6 @@
-*.annot
-*.cmo
-*.cma
-*.cmi
-*.a
-*.o
-*.cmx
-*.cmxs
-*.cmxa
-*.merlin
-
 _build/
-
 *.install
+*.merlin
 
 # latex
 *.tex

--- a/src/helpers/html.ml
+++ b/src/helpers/html.ml
@@ -20,44 +20,32 @@ let print_header _ =
      text-align: right;@;\
      white-space: nowrap;\
      @]@;}@;\
-     @[<v 4>.specification th::after {@;\
-     content: \"\\a0::=\\a0\";\
-     @]@;}@;\
      @[<v 4>.specification th.bar {@;\
      text-align: right;\
-     @]@;}@;\
-     @[<v 4>.specification th.bar::after {@;\
-     content: \"|\\a0\";\
      @]@;}@;\
      @[<v 4>.rule th, td {@;\
      padding-top: .5em;\
      @]@;}@;\
-     @[<v 4>.nonterminal::before {@;\
-     content: \"<\";\
-     @]@;}@;\
-     @[<v 4>.nonterminal::after {@;\
-     content: \">\";\
-     @]@;}@;\
-     @[<v 4>.list::after {@;\
-     content: \"*\";@;\
+     @[<v 4>.list_after {@;\
      vertical-align: super;@;\
      font-size: smaller;\
      @]@;}@;\
-     @[<v 4>.ne_list::after {@;\
-     content: \"+\";@;\
+     @[<v 4>.ne_list_after {@;\
      vertical-align: super;@;\
      font-size: smaller;\
      @]@;}@;\
-     @[<v 4>.option::before {@;\
-     content: \"[\";\
-     @]@;}@;\
-     @[<v 4>.option::after {@;\
-     content: \"]\";\
-     @]@;}\
      @]@;</style>\
      @]@;</head>@;@;\
      @[<v 2><body>@;@;\
      @[<v 2><table class=\"specification\">@;@;"
+
+let nonterminal_before = "&lt;"
+let nonterminal_after = "&gt;"
+let option_before = "["
+let option_after = "]"
+let list_after = "*"
+let ne_list_after = "+"
+let rule_def = "::="
 
 let print_footer () =
   print_string
@@ -65,15 +53,15 @@ let print_footer () =
      @]@;</body>@;\
      @]@;</html>@]@."
 
-let def () = "</th>@;<td>"
-let prod_bar () = "@[<v 2><tr>@;<th class=\"bar\"></th>@;<td>"
+let def () = Format.sprintf " %s </th>@;<td>" rule_def
+let prod_bar () = "@[<v 2><tr>@;<th class=\"bar\">|</th>@;<td>"
 let bar () = " | "
 let space () = "@ "
 let break () = "@;"
 let eps () = "epsilon"
 
 let print_rule_name =
-  print_rule_name_with "<th><span class=\"nonterminal\">" "</span>"
+  print_rule_name_with (Format.sprintf "<th>%s<span class=\"nonterminal\">" nonterminal_before) (Format.sprintf "</span>%s" nonterminal_after)
 
 let rule_begin () =
   print_string "@[<v 2><tr class=\"rule\">@;"
@@ -85,20 +73,28 @@ let production_end () =
   print_string "</td>@]@;</tr>"
 
 let print_symbol symbols =
-  print_symbol_aux "<span class=\"nonterminal\">" "</span>" symbols
+  print_symbol_aux (Format.sprintf "%s<span class=\"nonterminal\">" nonterminal_before) (Format.sprintf "</span>%s" nonterminal_after) symbols
 
 let opt _ print =
+  prerr_string option_before;
   print_string "<span class=\"option\">";
   print ();
-  print_string "</span>"
+  print_string "</span>";
+  print_string option_after
 
 let plus e print =
   print_string "<span class=\"ne_list\">";
   par e print;
+  print_string "</span>";
+  print_string "<span class=\"ne_list_after\">";
+  print_string ne_list_after;
   print_string "</span>"
 let star e print =
   print_string "<span class=\"list\">";
   par e print;
+  print_string "</span>";
+  print_string "<span class=\"list_after\">";
+  print_string list_after;
   print_string "</span>"
 
 let print_sep_list e nonempty print_sep print_x =


### PR DESCRIPTION
Hi,

Fix #12.

I made all content copy-pastable. The output is slightly different but still looks good to me.

> Oh yes I have troubles remembering the rationale behind this but I think I wanted users to be able to change the delimiters easily, so I thought it would be better to have theme handled by CSS...

So if I understood correctly, you wanted to allow customization a posteriori by editing the HTML file ? I guess a better way to do this would instead to add command line option to change them. I didn't do it in this PR but made sure the code is written so it's easy to add this feature.